### PR TITLE
Fix GH API path to include GH user

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,7 +63,7 @@ if [ -n "${INPUT_DESCRIPTION}" ]; then
   # If it was set to `true`, then fetch from Github.
   #   No quoting necessary, as it either returns a valid JSON string, or null
   if [ "${INPUT_DESCRIPTION}" = "true" ]; then
-    DESC=$(curl -s "https://api.github.com/repos/${SLUG}" | jq '.description')
+    DESC=$(curl -s "https://api.github.com/repos/${GITHUB_ACTOR}/${GITHUB_REPOSITORY}" | jq '.description')
   fi
 fi
 


### PR DESCRIPTION
The API call seems to miss the GH user and returns always `null` for me when running in terminal. `${SLUG}` only contains lowercased repo name, which might also fail?

Note: I have no idea what that `:-` does in line 34 + 35, can you enlighten me? 

For the API call on GH it should use the original GH user + repo name otherwise the to lowercased values (for DockerHub) will fail in this case? If I'm wrong I will replace the values with `$USER` and `$SLUG` 

Maybe this fixes #2 also. I had `description: true` and actually a description on my repo but it failed.